### PR TITLE
Handle auth errors properly

### DIFF
--- a/src/app/components/loginpage/loginpage.component.ts
+++ b/src/app/components/loginpage/loginpage.component.ts
@@ -26,14 +26,18 @@ export class LoginpageComponent implements OnInit {
   ngOnInit() {}
 
   loginUser() {
-    try{
-      if(this.signinForm.valid){
-        this.authService.signIn(this.signinForm.value);
-      }
-    }catch(e){ 
-      this.invalidLogin = true;
-      console.log(this.invalidLogin);
-      window.alert("Invalid Credentials");
+    if (this.signinForm.valid) {
+      this.authService.signIn(this.signinForm.value).subscribe({
+        next: profileData => {
+          alert(JSON.stringify(profileData)); // TODO: delete this line
+          this.router.navigate(['mainpage']);
+        },
+        error: err => {
+          this.invalidLogin = true;
+          console.error('Login error:', err); // TODO: delete this line
+          window.alert("Invalid Credentials");
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
Made login errors handled correctly. It resolves #1 

Throwing the error is not exactly needed. HttpClient throws it for you in this line, when it gets error response from the server (or when the request is timed out):
```ts
this.http.post<any>(`${this.endpoint}/login`, user)
```

You can handle the error in the `subscribe()` call, as you can see in the commit.

Further reading about RxJs Observables:
- [RxJs Operators](https://rxjs.dev/guide/operators) 
- [switchMap operator](https://rxjs.dev/api/operators/switchMap)
- [Subscribe arguments](https://rxjs.dev/deprecations/subscribe-arguments)